### PR TITLE
Change use of short array definition to old array()

### DIFF
--- a/src/Plates.php
+++ b/src/Plates.php
@@ -68,6 +68,6 @@ class Plates extends \Slim\View
     {
         $platesTemplate = new \League\Plates\Template\Template($this->getInstance(), $template);
         $platesTemplate->data($this->all());
-        return $platesTemplate->render(is_array($data) ? $data : []);
+        return $platesTemplate->render(is_array($data) ? $data : array());
     }
 }


### PR DESCRIPTION
The short array notation need PHP 5.4+ and in the composer.json you not specified nothing.
For backward compatibiliy i change to old array definition style.
Note: I use PHP 5.3 and Slim 2.6