### PR TITLE
Update Plates.php

### DIFF
--- a/src/Plates.php
+++ b/src/Plates.php
@@ -68,6 +68,6 @@ class Plates extends \Slim\View
     {
         $platesTemplate = new \League\Plates\Template\Template($this->getInstance(), $template);
         $platesTemplate->data($this->all());
-        return $platesTemplate->render(is_array($data) ? $data : []);
+        return $platesTemplate->render(is_array($data) ? $data : array());
     }
 }


### PR DESCRIPTION
In Line 71 you use the short array format but this broke the compatibility with PHP 5.3.
This version of package use Plates 3 and this version is compatible (At this moment 3.3.0) with php: ^5.3 | ^7.0